### PR TITLE
unnecessary method

### DIFF
--- a/WebApplication1/WalletID.cs
+++ b/WebApplication1/WalletID.cs
@@ -57,15 +57,7 @@ namespace BlockchainAnalysisTool
 
 
 
-        //* WalletID
-        // * 
-        // * Overload for construtor that takes a single Address 
-        // */
-        public WalletID(string initAddress) : this(new List<string>() { initAddress })
-        {
-            
-        }
-
+        
 
 
         /* addAddresses()


### PR DESCRIPTION
Anyone need this?
//* WalletID
        // * 
        // * Overload for construtor that takes a single Address 
        // */
        public WalletID(string initAddress) : this(new List<string>() { initAddress })
        {
            
        }